### PR TITLE
Update GIFEncoder.js

### DIFF
--- a/src/GIFEncoder.js
+++ b/src/GIFEncoder.js
@@ -291,7 +291,7 @@ class GIFEncoder extends EventEmitter {
     if (quality < 1) {
       quality = 1
     }
-    this.quality = quality
+    this.sample = quality
   }
 
   setThreshold(threshold) {


### PR DESCRIPTION
setQuality set a wrong quality variable instead of the sample one